### PR TITLE
Fix some README markdown funkiness.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ This project attempts to bring the Steam Deck's Holo OS into a generic, installa
 **Common Questions**
 
 - Is this official?
-> No, but it may as well be 99% of the way there. The code, and packages are straight from Valve with zero possible edits, and the ISO is being built on the official Steam Deck recovery image, running inside a QEMU instance.
+> No, but it may as well be 99% of the way there. The code and packages, are straight from Valve, with zero possible edits, and the ISO is being built on the official Steam Deck recovery image, running inside a QEMU instance.
 - The ISO didn't boot for me, any solution?
-> Currently, ISO only boots if flashed using [BalenaEtcher](https://www.balena.io/etcher/), [RosaImageWriter](http://wiki.rosalab.ru/en/index.php/ROSA_ImageWriter), [Fedora Media Writer](https://getfedora.org/en/workstation/download/), DD with 4MB block size, or [Rufus](https://rufus.ie) with DD mode.
+> Currently, the ISO only boots if flashed using [BalenaEtcher](https://www.balena.io/etcher/), [RosaImageWriter](http://wiki.rosalab.ru/en/index.php/ROSA_ImageWriter), [Fedora Media Writer](https://getfedora.org/en/workstation/download/), DD with 4MB block size, or [Rufus](https://rufus.ie) with DD mode.
 
 
 **Working stuff:**
@@ -31,8 +31,8 @@ This project attempts to bring the Steam Deck's Holo OS into a generic, installa
 
 **Known issues:**
 - NVIDIA GPUs are stuck on black screen or `Triggering uevents`. 
-> Solution: Boot with `nomodeset=1` and install [proprietary drivers](https://wiki.archlinux.org/title/NVIDIA). Keep in mind, that Steam Deck session won't work for now, delete `/etc/sddm.conf.d/autologin.conf` to avoid booting into black screen with infinite crash.
-- Intel GPUs/iGPUs require a Gamescope and MESA downgrade in order to boot into Steam Deck session. 
+> Solution: Boot with `nomodeset=1` and install [proprietary drivers](https://wiki.archlinux.org/title/NVIDIA). Keep in mind, that Steam Deck session won't work for now, delete `/etc/sddm.conf.d/autologin.conf` to avoid booting into a black screen with an infinite crash.
+- Intel GPUs/iGPUs require a Gamescope and MESA downgrade in order to boot into the Steam Deck session. 
 > Refer to [this gist](https://gist.github.com/drraccoony/8a8d0a9e3dfde9fafd3e374e418d2935) for further guidance.
 
 Installation process:
@@ -45,18 +45,19 @@ Installation process:
 
 **Installation types:**
 - barebones 
-> Barebones OS-only installation, resembles vanilla Arch Linux installation.
-`- gameonly 
-> Steam Deck UI only (AMD GPU only; no desktop), as said, this doesn't ship any DE, and only has Steam Deck UI installed.` This part is currently under a renovation.
+> An OS-only installation, resembles vanilla Arch Linux installation.
+- gameonly*
+> Steam Deck UI only (AMD GPU only; no desktop), as said, this doesn't ship any DE, and only has the Steam Deck UI installed. 
+> ****This part is currently under a renovation.***
 - deckperience
-> Full SteamOS 3 experience, Includes proper session switching, KDE Plasma and media apps, Chromium preinstalled.
+> Full SteamOS 3 experience, Includes proper session switching, KDE Plasma + media apps, and Chromium pre-installed.
 
 **Installation:**
 - Flash the ISO from [releases](https://github.com/bhaiest/holoiso/releases/latest) using [BalenaEtcher](https://www.balena.io/etcher/), [Rufus](https://rufus.ie) with DD mode, or by typing `sudo dd if=SteamOS.iso of=/dev/sd(your flash drive) bs=4M status=progress oflag=sync`
 - Boot into ISO
 - Run `holoinstall`
 - Enter drive node, starting from, for example, `sda` or `nvme0n1` when asked
-- Take your favourite hot beverage, and wait till it installs :)
+- Take your favourite hot beverage, and wait 'till it installs :3
 
 Upon booting, you'll be greeted with Steam Deck's OOBE screen, from where you'll connect to your network, and login to your Steam account, from there, you can exit to KDE Plasma seamlessly by choosing *Switch to desktop* in the power menu, [like so](https://www.youtube.com/watch?v=smfwna2iHho).
 

--- a/airootfs/usr/local/bin/holoinstall
+++ b/airootfs/usr/local/bin/holoinstall
@@ -46,11 +46,10 @@ select_disk() {
 			DEVICE="/dev/$DISKNO"
 		fi 
 	fi
-	echo -n "${DEVICE}"
 }
 
 base_os_install() {
-	DEVICE=`select_disk`
+	select_disk
 
 	if [ -z "${DEVICE}" ]; then
 		echo "Exiting..."
@@ -163,15 +162,15 @@ full_install() {
 	arch-chroot ${HOLO_INSTALL_DIR} systemctl enable sddm
 }
 
+
 # The installer itself. Good wuck.
-select_disk
 echo "SteamOS 3 Installer, version SteamOS_Holo_RC1-20220505_0837_amdgpu-x86_64"
 echo "Start time: $(date)"
 echo "Please choose installation type:"
 echo "1) barebones: Barebones OS-only installation"
 echo "2) deckperience: Full SteamOS 3 experience"
 read "?Enter your choice here: " HOLO_INSTALL_TYPE
-
+echo ""
 if [[ "${HOLO_INSTALL_TYPE}" == "1" ]] || [[ "${HOLO_INSTALL_TYPE}" == "barebones" ]]; then
 	echo "Installing SteamOS, barebones configuration..."
 	base_os_install

--- a/airootfs/usr/local/bin/holoinstall
+++ b/airootfs/usr/local/bin/holoinstall
@@ -24,20 +24,50 @@ else
 	UCODE_INSTALL="intel-ucode"
 fi
 
-base_os_install() {
-	lsblk
-	read "?Enter your desired drive node here (for example, sda or nvme0n1): " DRIVEDEVICE
+select_disk() {
+	local ALLDISKS=(`lsblk -o NAME,TYPE -lnp | grep disk | awk '{ print $1 }'`)
+	i=1
+	for disk in $ALLDISKS; do
+		echo "${i}. ${disk}"
+		i=$((i+1))
+	done
+
+	read "?Enter your desired disk number here (or, if not available, enter the disk's name manually): " DISKNO
 	read "?WARNING: This drive is going to be erased fully. Press enter to continue, or CTRL+Z to terminate"
-	
-	DEVICE="/dev/${DRIVEDEVICE}"
-	
-	INSTALLDEVICE="${DEVICE}"
-	echo ${DEVICE} | grep -q -P "^/dev/(nvme|loop|mmcblk)"
-	if [ $? -eq 0 ]; then
-		INSTALLDEVICE="${DEVICE}p"
+
+	# if $DISKNO is numeric
+	if [[ "$DISKNO" == <-> ]]; then
+		DISKNO=$((DISKNO-1))
+		DEVICE="${ALLDISKS:${DISKNO}}"
+	else
+		if [[ "$DISKNO" =~ "^/dev/" ]]; then
+			DEVICE="$DISKNO"
+		else
+			DEVICE="/dev/$DISKNO"
+		fi 
 	fi
-	
-	echo "\nCreating partitions..."
+	echo -n "${DEVICE}"
+}
+
+base_os_install() {
+	DEVICE=`select_disk`
+
+	if [ -z "${DEVICE}" ]; then
+		echo "Exiting..."
+		exit 0
+	fi
+
+	if ! [ -b "${DEVICE}" ]; then
+		echo "${DEVICE} is not a block device. Exiting..."
+		exit 1
+	fi
+
+	INSTALL_DEVICE="${DEVICE}"
+	if echo ${DEVICE} | grep -q -P "^/dev/(nvme|loop|mmcblk)"; then
+		INSTALL_DEVICE="${DEVICE}p"
+	fi
+
+	echo "\nPartitioning drive..."
 	sfdisk --delete ${DEVICE}
 	wipefs -a ${DEVICE}
 	parted ${DEVICE} mklabel gpt
@@ -45,13 +75,13 @@ base_os_install() {
 	parted ${DEVICE} set 1 boot on
 	parted ${DEVICE} set 1 esp on
 	parted ${DEVICE} mkpart primary btrfs 256M 100%
-	root_partition="${INSTALLDEVICE}2"
-	mkfs -t vfat ${INSTALLDEVICE}1
-	fatlabel ${INSTALLDEVICE}1 HOLOEFI
+	root_partition="${INSTALL_DEVICE}2"
+	mkfs -t vfat ${INSTALL_DEVICE}1
+	fatlabel ${INSTALL_DEVICE}1 HOLOEFI
 	mkfs -t btrfs -f ${root_partition}
 	btrfs filesystem label ${root_partition} holo-root
 
-	echo "\nPartition creating complete, mounting and pacstrapping..."
+	echo "\nPartitioning complete, mounting and pacstrapping..."
 	echo "${UCODE_INSTALL_MSG}"
 	mount -t btrfs -o subvol=/,compress-force=zstd:1,discard,noatime,nodiratime ${root_partition} ${HOLO_INSTALL_DIR}
 	pacstrap -i ${HOLO_INSTALL_DIR} base base-devel ${UCODE_INSTALL} core/linux core/linux-headers linux-neptune linux-neptune-headers linux-firmware
@@ -82,7 +112,7 @@ base_os_install() {
 	echo "\nInstalling bootloader..."
 	arch-chroot ${HOLO_INSTALL_DIR} ${CMD_PACMAN_UPDATE}
 	mkdir ${HOLO_INSTALL_DIR}/boot/efi
-	mount -t vfat ${INSTALLDEVICE}1 ${HOLO_INSTALL_DIR}/boot/efi
+	mount -t vfat ${INSTALL_DEVICE}1 ${HOLO_INSTALL_DIR}/boot/efi
 	arch-chroot ${HOLO_INSTALL_DIR} ${CMD_PACMAN_INSTALL} core/grub efibootmgr inetutils mkinitcpio neofetch networkmanager sddm
 	arch-chroot ${HOLO_INSTALL_DIR} systemctl enable NetworkManager systemd-timesyncd
 	arch-chroot ${HOLO_INSTALL_DIR} grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=holo --removable
@@ -134,6 +164,7 @@ full_install() {
 }
 
 # The installer itself. Good wuck.
+select_disk
 echo "SteamOS 3 Installer, version SteamOS_Holo_RC1-20220505_0837_amdgpu-x86_64"
 echo "Start time: $(date)"
 echo "Please choose installation type:"
@@ -141,7 +172,7 @@ echo "1) barebones: Barebones OS-only installation"
 echo "2) deckperience: Full SteamOS 3 experience"
 read "?Enter your choice here: " HOLO_INSTALL_TYPE
 
-if [[ "${HOLO_INSTALL_TYPE}" == "1" ]]; then
+if [[ "${HOLO_INSTALL_TYPE}" == "1" ]] || [[ "${HOLO_INSTALL_TYPE}" == "barebones" ]]; then
 	echo "Installing SteamOS, barebones configuration..."
 	base_os_install
 	echo "Installation finished! You may reboot now, or type arch-chroot /mnt to make further changes"
@@ -152,7 +183,7 @@ elif [[ "${HOLO_INSTALL_TYPE}" == "cockpenisyiff" ]]; then
 	gamescope_only_install
 	echo "Installation finished! You may reboot now, or type arch-chroot /mnt to make further changes"
 
-elif [[ "${HOLO_INSTALL_TYPE}" == "2" ]]; then
+elif [[ "${HOLO_INSTALL_TYPE}" == "2" ]] || [[ "${HOLO_INSTALL_TYPE}" == "deckperience" ]]; then
 	echo "Installing SteamOS, deckperience configuration..."
 	base_os_install
 	full_install


### PR DESCRIPTION
This resolves some issues I spotted with **Installation types**, particularly the odd glob of the `gameonly` and `barebones` sections. Seems to have been introduced with the merging of #20 at the tail end of changes in that PR.

Additionally I have done further misc. work on the README, and may or may not have changed the `:)` to a `:3` in the install section :3c