### PR TITLE
Fix typo when mounting image. Also adding ability to not echo on terminal when entering password

### DIFF
--- a/airootfs/usr/local/bin/holoinstall
+++ b/airootfs/usr/local/bin/holoinstall
@@ -109,7 +109,7 @@ base_os_install() {
 	echo "\nInstalling bootloader..."
 	arch-chroot ${HOLO_INSTALL_DIR} ${CMD_PACMAN_UPDATE}
 	mkdir ${HOLO_INSTALL_DIR}/boot/efi
-	mount -t vfat ${INSTALL_DEVICE}1 ${HOLO_INSTALL_DIR}/boot/efi
+	mount -t vfat ${INSTALLDEVICE}1 ${HOLO_INSTALL_DIR}/boot/efi
 	arch-chroot ${HOLO_INSTALL_DIR} ${CMD_PACMAN_INSTALL} core/grub efibootmgr inetutils mkinitcpio neofetch networkmanager sddm
 	arch-chroot ${HOLO_INSTALL_DIR} systemctl enable NetworkManager systemd-timesyncd
 	arch-chroot ${HOLO_INSTALL_DIR} grub-install --target=x86_64-efi --efi-directory=/boot/efi --bootloader-id=holo --removable

--- a/airootfs/usr/local/bin/holoinstall
+++ b/airootfs/usr/local/bin/holoinstall
@@ -61,11 +61,43 @@ base_os_install() {
 	cp /etc/pacman.conf /mnt/etc/pacman.conf
 	cp /etc/pacman.d/mirrorlist /mnt/etc/pacman.d/mirrorlist
 
-	read "?Enter your hostname for this installation: " HOLOHOSTNAME
+	read "?Enter hostname for this installation: " HOLOHOSTNAME
 	echo ${HOLOHOSTNAME} > ${HOLO_INSTALL_DIR}/etc/hostname
-	read "?Enter your username for this installation: " HOLOUSER
-	read "?Enter your user password for this installation: " HOLOPASS
-	read "?Enter your root password for this installation: " ROOTPASS
+	# Setup password for root
+	while true; do
+		echo -n "Enter \"root\" password for this installation(will not echo): "
+		read -s ROOTPASS
+		echo
+		echo -n "Enter \"root\" password for this installation(again): "
+		read -s ROOTPASS_CONF
+		echo
+		if [ $ROOTPASS = $ROOTPASS_CONF ]; then
+			break
+		fi
+		echo "Error: Password does not match."
+	done
+	# Create user
+	while true; do
+		read "?Enter username for this installation: " HOLOUSER
+		if [ $HOLOUSER = "root" ]; then
+			echo "User \"root\" already exists!"
+		else
+			break
+		fi
+	done
+	# Setup password for user
+	while true; do
+		echo -n "Enter \"$HOLOUSER\" password for this installation(will not echo): "
+		read -s HOLOPASS
+		echo
+		echo -n "Enter \"$HOLOUSER\" password for this installation(again): "
+		read -s HOLOPASS_CONF
+		echo
+		if [ $HOLOPASS = $HOLOPASS_CONF ]; then
+			break
+		fi
+		echo "Error: Password does not match."
+	done
 	echo "\nCreating user ${HOLOUSER}..."
 	echo -e "${ROOTPASS}\n${ROOTPASS}" | arch-chroot ${HOLO_INSTALL_DIR} passwd root
 	arch-chroot ${HOLO_INSTALL_DIR} useradd --create-home ${HOLOUSER}


### PR DESCRIPTION
This pull request fix the following issue:
1. A typo prevent mounting efi partition when installing bootloader.
2. Add ability to not showing password when entering the password. Therefore user need to type password twice for confirmation.