### PR TITLE
Correct ~/Desktop ownership issue and update README build dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Building the ISO:
 -
 Trigger the build by executing:
 ```
-pacman -Sy squashfs-tools arch-install-scripts mtools libburn libisofs libisoburn
+pacman -Sy archiso
 git clone https://github.com/bhaiest/holoiso/
 sudo mkarchiso -v holoiso
 ```

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Building the ISO:
 -
 Trigger the build by executing:
 ```
+pacman -Sy squashfs-tools arch-install-scripts mtools libburn libisofs libisoburn
 git clone https://github.com/bhaiest/holoiso/
 sudo mkarchiso -v holoiso
 ```

--- a/airootfs/usr/local/bin/holoinstall
+++ b/airootfs/usr/local/bin/holoinstall
@@ -149,6 +149,7 @@ full_install() {
 	cp /etc/holoinstall/steamos-gamemode.desktop /mnt/home/${HOLOUSER}/Desktop/steamos-gamemode.desktop
 	arch-chroot ${HOLO_INSTALL_DIR} chmod +x /home/${HOLOUSER}/Desktop/steamos-gamemode.desktop
 	arch-chroot ${HOLO_INSTALL_DIR} ln -s /usr/share/applications/steam.desktop /home/${HOLOUSER}/Desktop/steam.desktop
+	arch-chroot ${HOLO_INSTALL_DIR} chown -R ${HOLOUSER}:${HOLOUSER} /home/${HOLOUSER}/Desktop
 	arch-chroot ${HOLO_INSTALL_DIR} systemctl enable cups bluetooth sddm
 	arch-chroot ${HOLO_INSTALL_DIR} usermod -a -G rfkill ${HOLOUSER}
 	arch-chroot ${HOLO_INSTALL_DIR} sudo -u ${HOLOUSER} steam


### PR DESCRIPTION
I noticed that after installing holoiso ~/Desktop was still owned by root.  The root cause appears to be that it's created by root, but the owner isn't explicitly set.  This PR corrects that condition.

During testing I also walked through installing the necessary dependencies to build the ISO and updated the README to include them.

Upon testing the ownership of ~/Desktop and the content within it is now correct.