### PR TITLE
Adding NTP time syncing before install.

### DIFF
--- a/airootfs/usr/local/bin/holoinstall
+++ b/airootfs/usr/local/bin/holoinstall
@@ -16,6 +16,16 @@ else
 	exit
 fi
 
+# Update system time
+if [ $(timedatectl status | grep -c "NTP service: active") -ne 1 ]; then
+	# If NTP is not active, enable it.
+	timedatectl set-ntp true
+	
+	# Update the hardware clock.
+	hwclock --systohc
+fi
+
+
 if [[ "${CPU_VENDOR}" == "AuthenticAMD" ]]; then
 	UCODE_INSTALL_MSG="AMD CPU detected, installing AMD ucode..."
 	UCODE_INSTALL="amd-ucode"


### PR DESCRIPTION
Should resolve "SSL certificate problem: certificate not yet valid" issue caused by hardware clock not being correct.  I have tested the logic against the bootable ISO, but have not attempted to rebuild the ISO and install using this code.

The commands are taken from the Arch installation guide.