### PR TITLE
Re-issue PR that corrects a few issues.

### DIFF
--- a/airootfs/usr/local/bin/holoinstall
+++ b/airootfs/usr/local/bin/holoinstall
@@ -203,6 +203,7 @@ full_install() {
 	arch-chroot ${HOLO_INSTALL_DIR} sudo -u ${HOLOUSER} steam
 	arch-chroot ${HOLO_INSTALL_DIR} ${CMD_PACMAN_INSTALL} flatpak packagekit-qt5 rsync unzip vim
 	arch-chroot ${HOLO_INSTALL_DIR} flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+	arch-chroot ${HOLO_INSTALL_DIR} echo "recoveryinit" > /root/.bashrc
 }
 
 

--- a/airootfs/usr/local/bin/holoinstall
+++ b/airootfs/usr/local/bin/holoinstall
@@ -73,7 +73,7 @@ base_os_install() {
 	# If the available storage is less than 64GB, don't create /home.
 	# If the boot device is mmcblk0, don't create an ext4 partition or it will break steamOS versions
 	# released after May 20.
-	if [ "$(awk '/'${DEVICE}'/ {print $3; exit}' /proc/partitions)" -lt 64000000 ] || [[ "${DEVICE}" =~ mmcblk0 ]]; then
+	if [ "$(awk '/'${DRIVEDEVICE}'/ {print $3; exit}' /proc/partitions)" -lt 64000000 ] || [[ "${DEVICE}" =~ mmcblk0 ]]; then
 		parted ${DEVICE} mkpart primary btrfs 256M 100%
 	else
 		parted ${DEVICE} mkpart primary btrfs 256M 24G

--- a/airootfs/usr/local/bin/holoinstall
+++ b/airootfs/usr/local/bin/holoinstall
@@ -166,28 +166,23 @@ full_install() {
     sleep 1
     # The actual installation begins here:
 	arch-chroot ${HOLO_INSTALL_DIR} ${CMD_PACMAN_UPDATE}
-	arch-chroot ${HOLO_INSTALL_DIR} ${CMD_PACMAN_INSTALL} holoiso-main holoiso-updateclient wireplumber
+	arch-chroot ${HOLO_INSTALL_DIR} ${CMD_PACMAN_INSTALL} holoiso-main holoiso-updateclient wireplumber vulkan-radeon lib32-vulkan-radeon extra/vulkan-intel multilib/lib32-vulkan-intel
 	sleep 1
-	while true
-	do
-	   	echo "Please choose your current GPU:"
-	    	echo "1) AMD only: Will install updated Gamescope with Mangohud and FSR support"
-	    	echo "2) Intel: Will install older Gamescope that's compatible with Intel GPUs but without Mangohud and FSR support"
-	    	read "?Enter your choice here: " HOLO_GPU_TYPE
+   	echo "Please choose your current GPU:"
+    	echo "1) AMD only: Will install updated Gamescope with Mangohud and FSR support"
+    	echo "2) Intel: Will install older Gamescope that's compatible with Intel GPUs but without Mangohud and FSR support"
+    	read "?Enter your choice here: " HOLO_GPU_TYPE
 
-		if [[ "${HOLO_GPU_TYPE}" == "1" ]]; then
-	        	echo "Installing gamescope for AMD GPUs..."
-			arch-chroot ${HOLO_INSTALL_DIR} sed -i "s#IgnorePkg = gamescope #IgnorePkg = #g" /etc/pacman.conf
-	        	GAMESCOPE_INSTALL=(/usr/bin/pacman --noconfirm -S --needed --overwrite="*" vulkan-radeon lib32-vulkan-radeon gamescope)
-			break
-	    	elif [[ "${HOLO_GPU_TYPE}" == "2" ]]; then
-	        	echo "Installing gamescope for Intel GPUs..."
-	        	GAMESCOPE_INSTALL=(/usr/bin/pacman --noconfirm -S --needed --overwrite="*" extra/vulkan-intel multilib-lib32-vulkan-intel extra/mesa multilib/lib32-mesa holo/gamescope)
-			break
-	    	else
-        		echo -e "You have made an invalid selection, please try again...\n"
-		fi
-	done
+    	if [[ "${HOLO_GPU_TYPE}" == "1" ]]; then
+        	echo "Installing gamescope for AMD GPUs..."
+        	GAMESCOPE_INSTALL=(/usr/bin/pacman --noconfirm -S --needed --overwrite="*" gamescope)
+    	elif [[ "${HOLO_GPU_TYPE}" == "2" ]]; then
+        	echo "Installing gamescope for Intel GPUs..."
+        	GAMESCOPE_INSTALL=(/usr/bin/pacman --noconfirm -S --needed --overwrite="*" extra/mesa multilib/lib32-mesa holo/gamescope)
+    	else
+        	echo "Nothing choosed or Invalid choice. Installing gamescope for Intel GPUs..."
+        	GAMESCOPE_INSTALL=(/usr/bin/pacman --noconfirm -S --needed --overwrite="*" extra/mesa multilib/lib32-mesa holo/gamescope)
+    fi
 	echo "\nConfiguring Steam Deck UI by default..."
 	arch-chroot ${HOLO_INSTALL_DIR} ${GAMESCOPE_INSTALL}
 	mkdir ${HOLO_INSTALL_DIR}/etc/sddm.conf.d
@@ -199,9 +194,8 @@ full_install() {
 	arch-chroot ${HOLO_INSTALL_DIR} chown -R ${HOLOUSER}:${HOLOUSER} /home/${HOLOUSER}/Desktop
 	arch-chroot ${HOLO_INSTALL_DIR} systemctl enable cups bluetooth sddm holoiso-reboot-tracker
 	arch-chroot ${HOLO_INSTALL_DIR} usermod -a -G rfkill ${HOLOUSER}
-	arch-chroot ${HOLO_INSTALL_DIR} usermod -a -G wheel ${HOLOUSER}
 	arch-chroot ${HOLO_INSTALL_DIR} sudo -u ${HOLOUSER} steam
-	arch-chroot ${HOLO_INSTALL_DIR} ${CMD_PACMAN_INSTALL} flatpak packagekit-qt5 rsync unzip vim
+	arch-chroot ${HOLO_INSTALL_DIR} ${CMD_PACMAN_INSTALL} flatpak
 	arch-chroot ${HOLO_INSTALL_DIR} flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 	arch-chroot ${HOLO_INSTALL_DIR} echo "recoveryinit" > /root/.bashrc
 }

--- a/profiledef.sh
+++ b/profiledef.sh
@@ -3,7 +3,7 @@
 
 iso_name="SteamOS_Holo"
 iso_label="HOLO_$(date +%Y%m)"
-iso_publisher="$(git config --get user.name) <$(git config --get remote.origin.url | sed "s#^.*:#https://www.github.com/#g")>"
+iso_publisher="theVakhovske <https://github.com/bhaiest>"
 iso_application="SteamOS Live/Rescue CD"
 iso_version="$(date +%Y%m%d_%H%M)_amdgpu"
 install_dir="arch"


### PR DESCRIPTION
* Only add the Intel or AMD packages based on the menu selection.
* Don't default to Intel if no selection is made, ask again.
* Stop ignoring gamescope if AMD is selected.
* If the boot device is less than 64GB don't create a /home partition
  * On devices like my Atari VCS the previous behavior resulted in a 6GB /home which was full almost immediately by cache, etc.
 * If the boot device is mmcblk0, don't create /home or the system will fail to boot as mmcblk0 is trapped by udev and expected to be an SD card resulting in a non-bootable system.
* Install packagekit-qt5 which is required by discover, or it will not work correctly.
* Install rsync and unzip to correct an issue with EmuDeck installation failing.
* Install vim so we can edit files in recovery mode.

This is a re-issue of the earlier PR that also fixes an oversight that caused all devices to not provision a home directory.