### PR TITLE
Activate ext4 casefolding on /home while formatting

### DIFF
--- a/airootfs/usr/local/bin/holoinstall
+++ b/airootfs/usr/local/bin/holoinstall
@@ -83,7 +83,7 @@ base_os_install() {
 	mkfs -t vfat ${INSTALLDEVICE}1
 	fatlabel ${INSTALLDEVICE}1 HOLOEFI
 	mkfs -t btrfs -f ${root_partition}
-	mkfs -t ext4 ${INSTALLDEVICE}3
+	mkfs -t ext4 -O casefold ${INSTALLDEVICE}3
 	home_partition="${INSTALLDEVICE}3"
 	btrfs filesystem label ${root_partition} holo-root
 	e2label "${INSTALLDEVICE}3" holo-home


### PR DESCRIPTION
This activates casefolding on the /home partition.

It brings even more Compatibility for Windows Games.
Some Games, like SCP Containment Breach for example, have Library Names hardcoded in a diffrent Case than the Files shipped with the Game.

This change takes care of that because you can simply enable casefold on any folder you want with
`chattr +F <Foldername>`
(Folder must be Empty)