### PR TITLE
updates readme on building iso using docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,12 @@ sudo mkarchiso -v holoiso
 ```
 Once it ends, your ISO will be available in the `out` folder.
 
+Building the ISO using Docker:
+```
+# /path/to/some/dir can be any directory
+docker run -it -v /path/to/some/dir:/holo --cap-add ALL --privileged archlinux
+pacman -Sy archiso git
+git clone https://github.com/bhaiest/holoiso/
+mkarchiso -o /holo -v holoiso
+```
+After the build completes your ISO will be available in the `/path/to/some/dir` 


### PR DESCRIPTION
I wanted to build the iso myself but didn't have arch instance to use.  Docker with volume mount and elevated privileges works fine.   